### PR TITLE
feat(ingest): load files concurrently

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -19,6 +19,8 @@ SOURCE_DIRECTORY = f"{ROOT_DIRECTORY}/SOURCE_DOCUMENTS"
 
 PERSIST_DIRECTORY = f"{ROOT_DIRECTORY}/DB"
 
+INGEST_THREADS = 8
+
 # Define the Chroma settings
 CHROMA_SETTINGS = Settings(
         chroma_db_impl='duckdb+parquet',

--- a/ingest.py
+++ b/ingest.py
@@ -7,9 +7,12 @@ from langchain.embeddings import HuggingFaceInstructEmbeddings
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain.vectorstores import Chroma
 
-from constants import (CHROMA_SETTINGS, DOCUMENT_MAP, PERSIST_DIRECTORY,
+from constants import (CHROMA_SETTINGS, DOCUMENT_MAP, INGEST_THREADS, PERSIST_DIRECTORY,
                        SOURCE_DIRECTORY)
 
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import as_completed
 
 def load_single_document(file_path: str) -> Document:
     # Loads a single document from a file path
@@ -21,16 +24,44 @@ def load_single_document(file_path: str) -> Document:
         raise ValueError("Document type is undefined")
     return loader.load()[0]
 
+def load_document_batch(filepaths):
+    # create a thread pool
+    with ThreadPoolExecutor(len(filepaths)) as exe:
+        # load files
+        futures = [exe.submit(load_single_document, name) for name in filepaths]
+        # collect data
+        data_list = [future.result() for future in futures]
+        # return data and file paths
+        return (data_list, filepaths)
 
 def load_documents(source_dir: str) -> List[Document]:
     # Loads all documents from the source documents directory
     all_files = os.listdir(source_dir)
-    docs = []
+    paths = []
     for file_path in all_files:
         file_extension = os.path.splitext(file_path)[1]
         source_file_path = os.path.join(source_dir, file_path)
         if file_extension in DOCUMENT_MAP.keys():
-            docs.append(load_single_document(source_file_path))
+            paths.append(source_file_path)
+
+    n_workers = min(INGEST_THREADS, len(paths))
+    chunksize = round(len(paths) / n_workers)
+    docs = []
+    with ProcessPoolExecutor(n_workers) as executor:
+        futures = []
+        # split the load operations into chunks
+        for i in range(0, len(paths), chunksize):
+            # select a chunk of filenames
+            filepaths = paths[i:(i + chunksize)]
+            # submit the task
+            future = executor.submit(load_document_batch, filepaths)
+            futures.append(future)
+        # process all results
+        for future in as_completed(futures):
+            # open the file and load the data
+            contents, _ = future.result()
+            docs.extend(contents)
+
     return docs
 
 


### PR DESCRIPTION
Currently, all files are loaded in a single thread. 

This PR, based on [this article](https://superfastpython.com/multithreaded-file-loading/#Load_Files_Concurrently_With_Processes_and_Threads_in_Batch), will allow loading the documents in multiple threads which speeds up the process when having a lot of documents. 

By default, I have set 8 threads as this is a standard value, but it can be changed in `constants.py`.

Closes #76