### PR TITLE
Support for GPTQ quantized models

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ In order to set your environment up to run the code here, first install all requ
 ```shell
 pip install -r requirements.txt
 ```
+Then install AutoGPTQ - if you want to run quantized models for GPU
+```shell
+git clone https://github.com/PanQiWei/AutoGPTQ.git
+cd AutoGPTQ
+git checkout v0.2.2
+pip install .
+```
+For more support on [AutoGPTQ] (https://github.com/PanQiWei/AutoGPTQ).
 
 ## Test dataset
 This repo uses a [Constitution of USA ](https://constitutioncenter.org/media/files/constitution.pdf) as an example.

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -39,7 +39,6 @@ def load_model(device_type, model_id, model_basename=None):
     if model_basename is not None:
         # The code supports all huggingface models that ends with GPTQ and have some variation of .no-act.order or .safetensors in their HF repo.
         print('Using AutoGPTQForCausalLM for quantized models')
-        print('Using AutoGPTQForCausalLM for quantized models')
 
         if '.safetensors' in model_basename:
             # Remove the ".safetensors" ending if present

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -9,26 +9,58 @@ from langchain.llms import HuggingFacePipeline
 from langchain.vectorstores import Chroma
 from transformers import LlamaForCausalLM, LlamaTokenizer, pipeline
 from transformers import AutoTokenizer, AutoModelForCausalLM
+from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
 from constants import CHROMA_SETTINGS, PERSIST_DIRECTORY, ROOT_DIRECTORY
 from transformers import GenerationConfig
 
 
-def load_model(device_type):
+def load_model(device_type, model_id, model_basename=None):
     """
-    Select a model on huggingface.
+    Select a model for text generation using the HuggingFace library.
     If you are running this for the first time, it will download a model for you.
     subsequent runs will use the model from the disk.
-    """
-    # The code supports all huggingface models that ends with -HF or which have a .bin file in their HF repo.
-    model_id = "TheBloke/vicuna-7B-1.1-HF"
-    # model_id = "TheBloke/guanaco-7B-HF"
-    # model_id = 'NousResearch/Nous-Hermes-13b'
-    logging.info(f'Loading Model: {model_id}, on : {device_type}')
-    logging.info(f'This action can take a few minutes!')
 
-    if device_type.lower() == 'cuda':
+    Args:
+        device_type (str): Type of device to use, e.g., "cuda" for GPU or "cpu" for CPU.
+        model_id (str): Identifier of the model to load from HuggingFace's model hub.
+        model_basename (str, optional): Basename of the model if using quantized models. 
+            Defaults to None.
+
+    Returns:
+        HuggingFacePipeline: A pipeline object for text generation using the loaded model.
+
+    Raises:
+        ValueError: If an unsupported model or device type is provided.
+    """
+    
+    logging.info(f'Loading Model: {model_id}, on: {device_type}')
+    logging.info('This action can take a few minutes!')
+
+    if model_basename is not None:
+        # The code supports all huggingface models that ends with GPTQ and have some variation of .no-act.order or .safetensors in their HF repo.
+        print('Using AutoGPTQForCausalLM for quantized models')
+        print('Using AutoGPTQForCausalLM for quantized models')
+
+        if '.safetensors' in model_basename:
+            # Remove the ".safetensors" ending if present
+            model_basename = model_basename.replace('.safetensors', "")
+
+        tokenizer = AutoTokenizer.from_pretrained(model_id, use_fast=True)
+        logging.info('Tokenizer loaded')
+
+        model = AutoGPTQForCausalLM.from_quantized(
+            model_id,
+            model_basename=model_basename,
+            use_safetensors=True,
+            trust_remote_code=True,
+            device="cuda:0",
+            use_triton=False,
+            quantize_config=None
+        )
+    elif device_type.lower() == 'cuda': # The code supports all huggingface models that ends with -HF or which have a .bin file in their HF repo.
+        print('Using AutoModelForCausalLM for full models')
         tokenizer = AutoTokenizer.from_pretrained(model_id)
-        logging.info(f'Tokenizer loaded')
+        logging.info('Tokenizer loaded')
 
         model = AutoModelForCausalLM.from_pretrained(
             model_id,
@@ -39,14 +71,15 @@ def load_model(device_type):
         )
         model.tie_weights()
     else:
+        print('Using LlamaTokenizer')
         tokenizer = LlamaTokenizer.from_pretrained(model_id)
-        model = LlamaForCausalLM.from_pretrained(model_id, )
+        model = LlamaForCausalLM.from_pretrained(model_id)
 
-    # load configuration from the model to avoid warnings.
+    # Load configuration from the model to avoid warnings
     generation_config = GenerationConfig.from_pretrained(model_id)
     # see here for details: https://huggingface.co/docs/transformers/main_classes/text_generation#transformers.GenerationConfig.from_pretrained.returns
 
-    # create pipeline for text generation
+    # Create a pipeline for text generation
     pipe = pipeline(
         "text-generation",
         model=model,
@@ -59,7 +92,7 @@ def load_model(device_type):
     )
 
     local_llm = HuggingFacePipeline(pipeline=pipe)
-    logging.info(f'Local LLM Loaded')
+    logging.info('Local LLM Loaded')
 
     return local_llm
 
@@ -118,8 +151,21 @@ def main(device_type, show_sources):
     )
     retriever = db.as_retriever()
 
-    # load the LLM for generating Natural Language responses.
-    llm = load_model(device_type)
+    # load the LLM for generating Natural Language responses
+
+    # for HF models
+    # model_id = "TheBloke/vicuna-7B-1.1-HF"
+    # model_id = "TheBloke/Wizard-Vicuna-7B-Uncensored-HF"
+    # model_id = "TheBloke/guanaco-7B-HF"
+    # model_id = 'NousResearch/Nous-Hermes-13b' # Requires ~ 23GB VRAM. Using STransformers alongside will 100% create OOM on 24GB cards.
+    # llm = load_model(device_type, model_id=model_id)
+
+    # for GPTQ (quantized) models
+    model_id = "TheBloke/Nous-Hermes-13B-GPTQ"
+    model_basename = "nous-hermes-13b-GPTQ-4bit-128g.no-act.order"
+    # model_id = "TheBloke/WizardLM-30B-Uncensored-GPTQ"
+    # model_basename = "WizardLM-30B-Uncensored-GPTQ-4bit.act-order.safetensors" # Requires ~21GB VRAM. Using STransformers alongside can potentially create OOM on 24GB cards.
+    llm = load_model(device_type, model_id=model_id, model_basename = model_basename)
 
     qa = RetrievalQA.from_chain_type(
         llm=llm, chain_type="stuff", retriever=retriever, return_source_documents=True


### PR DESCRIPTION
Added support for GPTQ quantized models from HF. Moved model definitions to main along with descriptions of how to load in HF vs GPTQ models. Added to install instructions in the README for AutoGPTQ to get the quantized models running.