### PR TITLE
Add check for encoding argument during loader_class.

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -1,6 +1,7 @@
 import os
 from typing import List
 import logging
+import inspect
 
 import click
 from langchain.docstore.document import Document
@@ -21,7 +22,9 @@ def load_single_document(file_path: str) -> Document:
     file_extension = os.path.splitext(file_path)[1]
     loader_class = DOCUMENT_MAP.get(file_extension)
     if loader_class:
-        loader = loader_class(file_path)
+        args = inspect.getfullargspec(loader_class.__init__).args
+        kwargs = {'encoding': 'utf8'} if 'encoding' in args else {}
+        loader = loader_class(file_path, **kwargs)
     else:
         raise ValueError("Document type is undefined")
     return loader.load()[0]


### PR DESCRIPTION
Running Windows 10. Since my computer is in Japanese locale my text and cvs files default to utf-8 and are unable to be ingested. 
I added a check in load_single_document to default to encoding='utf8' if present in the class __init__.

Note: encoding is not in the excel loader nor the PDF Loader but is the default encoding in many other document_loaders from langchain.

Tested locally with my text and cvs files while still being able to ingest pdf files.