### PR TITLE
Issue-152 bug fix with --show_sources

### DIFF
--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -142,18 +142,13 @@ def load_model(device_type, model_id, model_basename=None):
 )
 @click.option(
     "--show_sources",
-    default=False,
-    type=click.Choice(
-        [
-            False,
-            True,
-        ]
-    ),
+    "-s",
+    is_default=True,
     help="Show sources along with answers (Default is False)",
 )
 def main(device_type, show_sources):
     """
-    This function implements the information retreival task.
+    This function implements the information retrieval task.
 
 
     1. Loads an embedding model, can be HuggingFaceInstructEmbeddings or HuggingFaceEmbeddings


### PR DESCRIPTION
Now by default the source documents are not show. If you add `--show_sources ` flag to when you run the `run_locaGPT.py`, it will show the sources: `python run_localGPT --show_sources`