### PR TITLE
[UI] Add argparse for specifying port and host

### DIFF
--- a/localGPTUI/localGPTUI.py
+++ b/localGPTUI/localGPTUI.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 import tempfile

--- a/localGPTUI/localGPTUI.py
+++ b/localGPTUI/localGPTUI.py
@@ -55,4 +55,12 @@ def home_page():
 
 
 if __name__ == "__main__":
-    app.run(debug=False, port=5111)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=5111,
+                        help="Port to run the UI on. Defaults to 5111.")
+    parser.add_argument("--host", type=str, default="127.0.0.1",
+                        help="Host to run the UI on. Defaults to 127.0.0.1. "
+                             "Set to 0.0.0.0 to make the UI externally "
+                             "accessible from other devices.")
+    args = parser.parse_args()
+    app.run(debug=False, host=args.host, port=args.port)


### PR DESCRIPTION
Adds argparse to `localGPTUI.py` to make it easier to specify custom ports and host (e.g., 0.0.0.0 to expose the webserver to the internet on a public machine). Defaults to 127.0.0.1:5111, so existing functionality and workflows are not affected. 