### PR TITLE
Subfolders in source doc

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -46,8 +46,8 @@ def load_documents(source_dir: str) -> list[Document]:
     all_files = []
     for root, dirs, files in os.walk(source_dir):
         for file in files:
-            all_files.append(os.path.join(root, file))
-            
+            all_files.append(os.path.join(root, file))  # append the file name with full path to the list
+
     paths = []
     for file_path in all_files:
         file_extension = os.path.splitext(file_path)[1]

--- a/ingest.py
+++ b/ingest.py
@@ -43,7 +43,11 @@ def load_document_batch(filepaths):
 
 def load_documents(source_dir: str) -> list[Document]:
     # Loads all documents from the source documents directory
-    all_files = os.listdir(source_dir)
+    all_files = []
+    for root, dirs, files in os.walk(source_dir):
+        for file in files:
+            all_files.append(os.path.join(root, file))
+            
     paths = []
     for file_path in all_files:
         file_extension = os.path.splitext(file_path)[1]


### PR DESCRIPTION
Add ability to have sub-folders in the SOURCE_DOCUMENT folder so you can copy paste your documents with their organization with out the need to flatten them.