### PR TITLE
cuBLAS support for GGML Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install conda
 conda create -n localGPT
 ```
 
-Activate 
+Activate
 
 ```shell
 conda activate localGPT
@@ -28,6 +28,13 @@ In order to set your environment up to run the code here, first install all requ
 
 ```shell
 pip install -r requirements.txt
+```
+
+If you want to use BLAS or Metal with [llama-cpp](<(https://github.com/abetlen/llama-cpp-python#installation-with-openblas--cublas--clblast--metal)>) you can set appropriate flags:
+
+```shell
+# Example: cuBLAS
+CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install -r requirements.txt
 ```
 
 Then install AutoGPTQ - if you want to run quantized models for GPU
@@ -57,7 +64,7 @@ Run the following command to ingest all the data.
 `defaults to cuda`
 
 ```shell
-python ingest.py 
+python ingest.py
 ```
 
 Use the device type argument to specify a given device.
@@ -260,40 +267,40 @@ Follow this [page](https://linuxconfig.org/how-to-install-the-nvidia-drivers-on-
 
 This is a test project to validate the feasibility of a fully local solution for question answering using LLMs and Vector embeddings. It is not production ready, and it is not meant to be used in production. Vicuna-7B is based on the Llama model so that has the original Llama license.
 
-
-
 # Common Errors
 
- - [Torch not compatible with cuda enabled](https://github.com/pytorch/pytorch/issues/30664)
+- [Torch not compatible with cuda enabled](https://github.com/pytorch/pytorch/issues/30664)
 
-   -  Get cuda version
+  - Get cuda version
 
-      ```shell
-      nvcc --version
-      ```
-      ```shell
-      nvidia-smi
-      ```
-   - Try Install pytorch fepending on your cuda version
-      ```shell
-         conda install -c pytorch torchvision cudatoolkit=10.1 pytorch
-      ```
-   - If doesn't work try re installing 
-      ```shell
-         pip uninstall torch
-         pip cache purge
-         pip install torch -f https://download.pytorch.org/whl/torch_stable.html
-      ```
+    ```shell
+    nvcc --version
+    ```
+
+    ```shell
+    nvidia-smi
+    ```
+
+  - Try Install pytorch fepending on your cuda version
+    ```shell
+       conda install -c pytorch torchvision cudatoolkit=10.1 pytorch
+    ```
+  - If doesn't work try re installing
+    ```shell
+       pip uninstall torch
+       pip cache purge
+       pip install torch -f https://download.pytorch.org/whl/torch_stable.html
+    ```
+
 - [ERROR: pip's dependency resolver does not currently take into account all the packages that are installed](https://stackoverflow.com/questions/72672196/error-pips-dependency-resolver-does-not-currently-take-into-account-all-the-pa/76604141#76604141)
-   ```shell
-      pip install h5py
-      pip install typing-extensions
-      pip install wheel
-   ```
+  ```shell
+     pip install h5py
+     pip install typing-extensions
+     pip install wheel
+  ```
 - [Failed to import transformers](https://github.com/huggingface/transformers/issues/11262)
-   - Try  re-install
-      ```shell
-         conda uninstall tokenizers, transformers
-         pip install transformers
-      ```
-
+  - Try re-install
+    ```shell
+       conda uninstall tokenizers, transformers
+       pip install transformers
+    ```

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -67,8 +67,9 @@ def load_model(device_type, model_id, model_basename=None):
             n_gpu_layers = 40  # Change this value based on your model and your GPU VRAM pool.
             n_batch = 512  # Should be between 1 and n_ctx, consider the amount of VRAM in your GPU.
             callback_manager = CallbackManager([StreamingStdOutCallbackHandler()])
+            model_path = hf_hub_download(repo_id=model_id, filename=model_basename)
             return LlamaCpp(
-                model_path="./ggml-model-q4_0.bin",
+                model_path=model_path,
                 n_gpu_layers=n_gpu_layers,
                 n_batch=n_batch,
                 verbose=True,

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -9,6 +9,7 @@ from langchain.embeddings import HuggingFaceInstructEmbeddings
 from langchain.llms import HuggingFacePipeline, LlamaCpp
 from langchain.callbacks.manager import CallbackManager
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+from functools import partial
 
 # from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.vectorstores import Chroma
@@ -46,19 +47,21 @@ def load_model(device_type, model_id, model_basename=None):
     logging.info("This action can take a few minutes!")
 
     if model_basename is not None:
-        if device_type.lower() in ["cpu", "mps"]:
-            logging.info("Using Llamacpp for quantized models")
+        if ".ggml" in model_basename:
+            logging.info("Using Llamacpp for GGML quantized models")
             model_path = hf_hub_download(repo_id=model_id, filename=model_basename)
+            kwargs = {
+                "model_path": model_path,
+                "n_ctx": 4096,
+                "max_tokens": 4096,
+                "temperature": 0,
+                "repeat_penalty": 1.15
+            }
             if device_type.lower() == "mps":
-                return LlamaCpp(
-                    model_path=model_path,
-                    n_ctx=2048,
-                    max_tokens=2048,
-                    temperature=0,
-                    repeat_penalty=1.15,
-                    n_gpu_layers=1000,
-                )
-            return LlamaCpp(model_path=model_path, n_ctx=2048, max_tokens=2048, temperature=0, repeat_penalty=1.15)
+                kwargs["n_gpu_layers"] = 1000
+            if device_type.lower() == "cuda":
+                kwargs["n_batch"] = 4096
+            return partial(LlamaCpp, **kwargs)
 
         else:
             # The code supports all huggingface models that ends with GPTQ and have some variation

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -64,11 +64,12 @@ def load_model(device_type, model_id, model_basename=None):
             # The code supports all huggingface models that ends with GPTQ and have some variation
             # of .no-act.order or .safetensors in their HF repo.
             logging.info("Using GGML for quantized models")
-            n_gpu_layers = 40  # Change this value based on your model and your GPU VRAM pool.
-            n_batch = 512  # Should be between 1 and n_ctx, consider the amount of VRAM in your GPU.
+            n_gpu_layers = 1000  # Change this value based on your model and your GPU VRAM pool.
+            n_batch = 4096  # Should be between 1 and n_ctx, consider the amount of VRAM in your GPU.
             callback_manager = CallbackManager([StreamingStdOutCallbackHandler()])
             model_path = hf_hub_download(repo_id=model_id, filename=model_basename)
             return LlamaCpp(
+                n_ctx=4096,
                 model_path=model_path,
                 n_gpu_layers=n_gpu_layers,
                 n_batch=n_batch,

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -9,7 +9,6 @@ from langchain.embeddings import HuggingFaceInstructEmbeddings
 from langchain.llms import HuggingFacePipeline, LlamaCpp
 from langchain.callbacks.manager import CallbackManager
 from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
-from functools import partial
 
 # from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.vectorstores import Chroma
@@ -61,7 +60,7 @@ def load_model(device_type, model_id, model_basename=None):
                 kwargs["n_gpu_layers"] = 1000
             if device_type.lower() == "cuda":
                 kwargs["n_batch"] = 4096
-            return partial(LlamaCpp, **kwargs)
+            return LlamaCpp(**kwargs)
 
         else:
             # The code supports all huggingface models that ends with GPTQ and have some variation

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -65,8 +65,8 @@ def load_model(device_type, model_id, model_basename=None):
             return LlamaCpp(
                 n_ctx=4096,
                 model_path=model_path,
-                n_gpu_layers=n_gpu_layers,
-                n_batch=n_batch,
+                n_gpu_layers=1000,
+                n_batch=4096,
                 verbose=True,
                 callback_manager=callback_manager
             )

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -56,7 +56,7 @@ def load_model(device_type, model_id, model_basename=None):
                 "max_tokens": 4096,
                 "temperature": 0,
                 "repeat_penalty": 1.15,
-                callback_manager: callback_manager
+                "callback_manager": callback_manager
             }
             if device_type.lower() == "mps":
                 kwargs["n_gpu_layers"] = 1000

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -7,7 +7,6 @@ from huggingface_hub import hf_hub_download
 from langchain.chains import RetrievalQA
 from langchain.embeddings import HuggingFaceInstructEmbeddings
 from langchain.llms import HuggingFacePipeline, LlamaCpp
-from langchain.callbacks.manager import CallbackManager
 
 # from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain.vectorstores import Chroma
@@ -48,18 +47,17 @@ def load_model(device_type, model_id, model_basename=None):
         if ".ggml" in model_basename:
             logging.info("Using Llamacpp for GGML quantized models")
             model_path = hf_hub_download(repo_id=model_id, filename=model_basename)
+            max_ctx_size = 2048
             kwargs = {
                 "model_path": model_path,
-                "n_ctx": 4096,
-                "max_tokens": 4096,
-                "temperature": 0,
-                "repeat_penalty": 1.15,
+                "n_ctx": max_ctx_size,
+                "max_tokens": max_ctx_size,
             }
             if device_type.lower() == "mps":
                 kwargs["n_gpu_layers"] = 1000
             if device_type.lower() == "cuda":
                 kwargs["n_gpu_layers"] = 1000
-                kwargs["n_batch"] = 4096
+                kwargs["n_batch"] = max_ctx_size
             return LlamaCpp(**kwargs)
 
         else:

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -49,12 +49,14 @@ def load_model(device_type, model_id, model_basename=None):
         if ".ggml" in model_basename:
             logging.info("Using Llamacpp for GGML quantized models")
             model_path = hf_hub_download(repo_id=model_id, filename=model_basename)
+            callback_manager = CallbackManager([StreamingStdOutCallbackHandler()])
             kwargs = {
                 "model_path": model_path,
                 "n_ctx": 4096,
                 "max_tokens": 4096,
                 "temperature": 0,
-                "repeat_penalty": 1.15
+                "repeat_penalty": 1.15,
+                callback_manager: callback_manager
             }
             if device_type.lower() == "mps":
                 kwargs["n_gpu_layers"] = 1000
@@ -68,7 +70,6 @@ def load_model(device_type, model_id, model_basename=None):
             logging.info("Using GGML for quantized models")
             n_gpu_layers = 1000  # Change this value based on your model and your GPU VRAM pool.
             n_batch = 4096  # Should be between 1 and n_ctx, consider the amount of VRAM in your GPU.
-            callback_manager = CallbackManager([StreamingStdOutCallbackHandler()])
             model_path = hf_hub_download(repo_id=model_id, filename=model_basename)
             return LlamaCpp(
                 n_ctx=4096,

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -62,7 +62,14 @@ def load_model(device_type, model_id, model_basename=None):
                 kwargs["n_gpu_layers"] = 1000
             if device_type.lower() == "cuda":
                 kwargs["n_batch"] = 4096
-            return LlamaCpp(**kwargs)
+            return LlamaCpp(
+                n_ctx=4096,
+                model_path=model_path,
+                n_gpu_layers=n_gpu_layers,
+                n_batch=n_batch,
+                verbose=True,
+                callback_manager=callback_manager
+            )
 
         else:
             # The code supports all huggingface models that ends with GPTQ and have some variation

--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -61,15 +61,9 @@ def load_model(device_type, model_id, model_basename=None):
             if device_type.lower() == "mps":
                 kwargs["n_gpu_layers"] = 1000
             if device_type.lower() == "cuda":
+                kwargs["n_gpu_layers"] = 1000
                 kwargs["n_batch"] = 4096
-            return LlamaCpp(
-                n_ctx=4096,
-                model_path=model_path,
-                n_gpu_layers=1000,
-                n_batch=4096,
-                verbose=True,
-                callback_manager=callback_manager
-            )
+            return LlamaCpp(**kwargs)
 
         else:
             # The code supports all huggingface models that ends with GPTQ and have some variation


### PR DESCRIPTION
cuBLAS support for GGML Models as pointed out in #242 
Currently there is no way to use GPU for GGML because using GGML is triggered by being on cpu or mps, [line 47 from run_localGPT.py](https://github.com/PromtEngineer/localGPT/blob/6f894706d9c371115d691f0d9e3b117fb42ba216/run_localGPT.py#L46C1-L46C1)
This is especially undesirable because the default behavior is to use llama 2 GGML and gpu is unused :'(

This ticket changes ggml logic to 
```python 
if ".ggml" in model_basename:
```
to match the current method of checking gptq with 
```python 
if ".safetensors" in model_basename:
```

LlamaCpp model is being instantiated with kwargs:
```python
            kwargs = {
                "model_path": model_path,
                "n_ctx": max_ctx_size,
                "max_tokens": max_ctx_size,
            }
            if device_type.lower() == "mps":
                kwargs["n_gpu_layers"] = 1000
            if device_type.lower() == "cuda":
                kwargs["n_gpu_layers"] = 1000
                kwargs["n_batch"] = max_ctx_size
            return LlamaCpp(**kwargs)
```
Note:
You need these flags when installing llama-python-cpp: `CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 `
I added to README.
Sources:
https://python.langchain.com/docs/modules/model_io/models/llms/integrations/llamacpp#gpu
https://github.com/abetlen/llama-cpp-python#installation-with-openblas--cublas--clblast--metal

I do not have a GPU, but I used on Colab and here is the output - notice the `BLAS = 1` count, `llama_model_load_internal: offloaded 35/35 layers to GPU`, and inference speeds on V100:
```bash
!python run_localGPT.py --device_type cuda
```
```bash
2023-07-24 00:51:03.445598: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Could not find TensorRT
2023-07-24 00:51:06,689 - INFO - run_localGPT.py:178 - Running on: cuda
2023-07-24 00:51:06,689 - INFO - run_localGPT.py:179 - Display Source Documents set to: False
2023-07-24 00:51:06,880 - INFO - SentenceTransformer.py:66 - Load pretrained SentenceTransformer: hkunlp/instructor-large
load INSTRUCTOR_Transformer
max_seq_length  512
2023-07-24 00:51:10,752 - INFO - __init__.py:88 - Running Chroma using direct local API.
2023-07-24 00:51:10,765 - WARNING - __init__.py:43 - Using embedded DuckDB with persistence: data will be stored in: /content/localGPT/DB
2023-07-24 00:51:10,772 - INFO - ctypes.py:22 - Successfully imported ClickHouse Connect C data optimizations
2023-07-24 00:51:10,779 - INFO - json_impl.py:45 - Using python library for writing JSON byte strings
2023-07-24 00:51:10,829 - INFO - duckdb.py:460 - loaded in 72 embeddings
2023-07-24 00:51:10,831 - INFO - duckdb.py:472 - loaded in 1 collections
2023-07-24 00:51:10,832 - INFO - duckdb.py:89 - collection with name langchain already exists, returning existing collection
2023-07-24 00:51:10,832 - INFO - run_localGPT.py:43 - Loading Model: TheBloke/Llama-2-7B-Chat-GGML, on: cuda
2023-07-24 00:51:10,832 - INFO - run_localGPT.py:44 - This action can take a few minutes!
2023-07-24 00:51:10,832 - INFO - run_localGPT.py:48 - Using Llamacpp for GGML quantized models
ggml_init_cublas: found 1 CUDA devices:
  Device 0: Tesla V100-SXM2-16GB
llama.cpp: loading model from /root/.cache/huggingface/hub/models--TheBloke--Llama-2-7B-Chat-GGML/snapshots/501a3c8182cd256a859888fff4e838c049d5d7f6/llama-2-7b-chat.ggmlv3.q4_0.bin
llama_model_load_internal: format     = ggjt v3 (latest)
llama_model_load_internal: n_vocab    = 32000
llama_model_load_internal: n_ctx      = 2048
llama_model_load_internal: n_embd     = 4096
llama_model_load_internal: n_mult     = 256
llama_model_load_internal: n_head     = 32
llama_model_load_internal: n_layer    = 32
llama_model_load_internal: n_rot      = 128
llama_model_load_internal: ftype      = 2 (mostly Q4_0)
llama_model_load_internal: n_ff       = 11008
llama_model_load_internal: n_parts    = 1
llama_model_load_internal: model size = 7B
llama_model_load_internal: ggml ctx size =    0.07 MB
llama_model_load_internal: using CUDA for GPU acceleration
llama_model_load_internal: mem required  = 1862.38 MB (+ 1026.00 MB per state)
llama_model_load_internal: allocating batch_size x 1 MB = 512 MB VRAM for the scratch buffer
llama_model_load_internal: offloading 32 repeating layers to GPU
llama_model_load_internal: offloading non-repeating layers to GPU
llama_model_load_internal: offloading v cache to GPU
llama_model_load_internal: offloading k cache to GPU
llama_model_load_internal: offloaded 35/35 layers to GPU
llama_model_load_internal: total VRAM used: 5084 MB
llama_new_context_with_model: kv self size  = 1024.00 MB
AVX = 1 | AVX2 = 1 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 1 | SSE3 = 1 | VSX = 0 | 

Enter a query: write a poem on alexander hamilton

llama_print_timings:        load time =  1872.60 ms
llama_print_timings:      sample time =   223.43 ms /   218 runs   (    1.02 ms per token,   975.70 tokens per second)
llama_print_timings: prompt eval time =  1872.37 ms /  1123 tokens (    1.67 ms per token,   599.78 tokens per second)
llama_print_timings:        eval time =  3977.00 ms /   217 runs   (   18.33 ms per token,    54.56 tokens per second)
llama_print_timings:       total time =  6753.88 ms


> Question:
write a poem on alexander hamilton

> Answer:
 I can certainly try! Here's a poem about Alexander Hamilton:
Alexander Hamilton, man of great might,
Father of our country, with all your might.
You shaped this nation with your vision so bright,
And left behind a legacy that's a true sight.
Your passion and perseverance paved the way,
For us to live in freedom and peace each day.
From immigrant to statesman, you rose to fame,
With eloquence and wit, you led the game.
In the Federalist Papers, your words of art,
Helped form our government, a work of heart.
You fought for justice and equality with all your might,
And left behind a legacy that's shining bright.
Your legacy lives on, a beacon of hope,
A testament to the power of perseverance and scope.
So here's to Alexander Hamilton, man of great might,
A hero who shaped our nation with all your might!
```