### PR TITLE
Modify `bitsandbytes` package requirement to detect whether

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,8 @@ docx2txt
 # Utilities
 urllib3==1.26.6
 accelerate
-bitsandbytes
+bitsandbytes ; sys_platform != 'win32'
+bitsandbytes-windows ; sys_platform == 'win32'
 click
 flask
 requests


### PR DESCRIPTION
Modify `bitsandbytes` package requirement to detect whether the user is on Windows, and use `bitsandbytes-windows` if so.

Fixes issue #265

 On branch issue_265_bitsandbytes_windows
 Changes to be committed:
	modified:   requirements.txt