### PR TITLE
handling python3 and python command

### DIFF
--- a/run_localGPT_API.py
+++ b/run_localGPT_API.py
@@ -221,7 +221,11 @@ def run_ingest_route():
         else:
             print("The directory does not exist")
 
-        run_langest_commands = ["python", "ingest.py"]
+        if shutil.which("python"):
+            run_langest_commands = ["python", "ingest.py"]
+        else:
+            run_langest_commands = ["python3", "ingest.py"]
+
         if DEVICE_TYPE == "cpu":
             run_langest_commands.append("--device_type")
             run_langest_commands.append(DEVICE_TYPE)

--- a/run_localGPT_API.py
+++ b/run_localGPT_API.py
@@ -43,7 +43,11 @@ if os.path.exists(PERSIST_DIRECTORY):
 else:
     print("The directory does not exist")
 
-run_langest_commands = ["python", "ingest.py"]
+if shutil.which("python"):
+    run_langest_commands = ["python", "ingest.py"]
+else:
+    run_langest_commands = ["python3", "ingest.py"]
+
 if DEVICE_TYPE == "cpu":
     run_langest_commands.append("--device_type")
     run_langest_commands.append(DEVICE_TYPE)
@@ -221,7 +225,7 @@ def run_ingest_route():
         if DEVICE_TYPE == "cpu":
             run_langest_commands.append("--device_type")
             run_langest_commands.append(DEVICE_TYPE)
-            
+
         result = subprocess.run(run_langest_commands, capture_output=True)
         if result.returncode != 0:
             return "Script execution failed: {}".format(result.stderr.decode("utf-8")), 500


### PR DESCRIPTION
Enables machines with only `python3` installed to run localGPT instead of just `python`.