### PR TITLE
remove manual AutoGPTQ instruction step from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,6 @@ If you want to use BLAS or Metal with [llama-cpp](<(https://github.com/abetlen/l
 CMAKE_ARGS="-DLLAMA_CUBLAS=on" FORCE_CMAKE=1 pip install -r requirements.txt
 ```
 
-Then install AutoGPTQ - if you want to run quantized models for GPU
-
-```shell
-git clone https://github.com/PanQiWei/AutoGPTQ.git
-cd AutoGPTQ
-git checkout v0.2.2
-pip install .
-```
-
-For more support on [AutoGPTQ](https://github.com/PanQiWei/AutoGPTQ).
-
 ## Test dataset
 
 This repo uses a [Constitution of USA ](https://constitutioncenter.org/media/files/constitution.pdf) as an example.


### PR DESCRIPTION
It is not needed anymore with the recent fixed version 0.2.2 in requirements.txt.