### PR TITLE
Token Length Text Splitter

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -8,6 +8,7 @@ from langchain.docstore.document import Document
 from langchain.embeddings import HuggingFaceInstructEmbeddings
 from langchain.text_splitter import Language, RecursiveCharacterTextSplitter
 from langchain.vectorstores import Chroma
+from transformers import AutoTokenizer
 
 from constants import (
     CHROMA_SETTINGS,
@@ -121,7 +122,10 @@ def main(device_type):
     logging.info(f"Loading documents from {SOURCE_DIRECTORY}")
     documents = load_documents(SOURCE_DIRECTORY)
     text_documents, python_documents = split_documents(documents)
-    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/llama-tokenizer")
+    text_splitter = RecursiveCharacterTextSplitter.from_huggingface_tokenizer(
+        tokenizer, chunk_size=512, chunk_overlap=100
+    )
     python_splitter = RecursiveCharacterTextSplitter.from_language(
         language=Language.PYTHON, chunk_size=1000, chunk_overlap=200
     )


### PR DESCRIPTION
Hey! I just wanted to put a ticket out for splitting text by token length and hope to gather feedback and iterate on this.
The TextSplitters on langchain allow for `length_function` customization, and there is a convienience function for doing it from huggingface tokenizer which seems to use:
```python
len(tokenizer.encode(text))
```

<img width="400" alt="Screen Shot 2023-08-13 at 10 46 30 PM" src="https://github.com/PromtEngineer/localGPT/assets/64715088/0e362cdc-2a12-4556-b3b9-d80ea3a31dae">  

[src - from api docs](https://api.python.langchain.com/en/latest/_modules/langchain/text_splitter.html#RecursiveCharacterTextSplitter)

I have tested this from `ingest.py` by using a for loop after the splitting like:
```python
    text_splitter = RecursiveCharacterTextSplitter.from_huggingface_tokenizer(
        tokenizer, chunk_size=512, chunk_overlap=100
    )
    texts = text_splitter.split_documents(text_documents)
    for i in texts:
        size = len(tokenizer.encode(i.page_content))
        if size > 512:
            print('whoops...')
        print(size)
```

Output:
```shell
2023-08-13 22:54:44,553 - INFO - ingest.py:122 - Loading documents from /Users/jeff/Documents/repos/localGPT/SOURCE_DOCUMENTS
418
471
486
443
390
296
394
452
431
445
412
452
326
499
436
448
401
483
464
460
437
337
427
431
432
487
452
96
430
303
396
406
460
443
443
472
463
400
416
462
473
302
2023-08-13 22:54:46,689 - INFO - ingest.py:140 - Loaded 1 documents from /Users/jeff/Documents/repos/localGPT/SOURCE_DOCUMENTS
2023-08-13 22:54:46,690 - INFO - ingest.py:141 - Split into 42 chunks of text
huggingface/tokenizers: The current process just got forked, after parallelism has already been used. Disabling parallelism to avoid deadlocks...
To disable this warning, you can either:
        - Avoid using `tokenizers` before the fork if possible
        - Explicitly set the environment variable TOKENIZERS_PARALLELISM=(true | false)
2023-08-13 22:54:47,294 - INFO - SentenceTransformer.py:66 - Load pretrained SentenceTransformer: hkunlp/instructor-large
load INSTRUCTOR_Transformer
max_seq_length  512
2023-08-13 22:54:49,859 - INFO - __init__.py:88 - Running Chroma using direct local API.
2023-08-13 22:54:50,133 - WARNING - __init__.py:43 - Using embedded DuckDB with persistence: data will be stored in: /Users/jeff/Documents/repos/localGPT/DB
2023-08-13 22:54:50,140 - INFO - ctypes.py:22 - Successfully imported ClickHouse Connect C data optimizations
2023-08-13 22:54:50,145 - INFO - json_impl.py:45 - Using orjson library for writing JSON byte strings
2023-08-13 22:54:50,247 - INFO - duckdb.py:460 - loaded in 315 embeddings
2023-08-13 22:54:50,247 - INFO - duckdb.py:472 - loaded in 1 collections
2023-08-13 22:54:50,248 - INFO - duckdb.py:89 - collection with name langchain already exists, returning existing collection
```

***I just want to note that I think the parallelism is broken. The warning seems to go away if the env var is set appropriately. I don't think there is a current way to load a .env in the project, but running this seems to work:*** 
```shell
export TOKENIZERS_PARALLELISM=true
```