### PR TITLE
add resume_download as default to hf_hub_download

### DIFF
--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -48,7 +48,7 @@ def load_model(device_type, model_id, model_basename=None):
     if model_basename is not None:
         if ".ggml" in model_basename:
             logging.info("Using Llamacpp for GGML quantized models")
-            model_path = hf_hub_download(repo_id=model_id, filename=model_basename)
+            model_path = hf_hub_download(repo_id=model_id, filename=model_basename, resume_download=True)
             max_ctx_size = 2048
             kwargs = {
                 "model_path": model_path,


### PR DESCRIPTION
when download large model from huggingface, there is often a TimeoutError, add resume_download to avoid to rerun from start