### PR TITLE
added error message for load_quantized_model_gguf_ggml

### DIFF
--- a/load_models.py
+++ b/load_models.py
@@ -54,9 +54,10 @@ def load_quantized_model_gguf_ggml(model_id, model_basename, device_type, loggin
             kwargs["n_gpu_layers"] = N_GPU_LAYERS  # set this based on your GPU
 
         return LlamaCpp(**kwargs)
-    except:
+    except Exception as e:
         if "ggml" in model_basename:
             logging.INFO("If you were using GGML model, LLAMA-CPP Dropped Support, Use GGUF Instead")
+        logging.info(f"LlamaCpp conversion error: {e}")
         return None
 
 


### PR DESCRIPTION
I was facing this issue. The error was not super intuitive. I debugged it using the VSCODE debugger:

https://github.com/PromtEngineer/localGPT/issues/490

```
{

    "version": "0.2.0",
    "configurations": [
        {
            "name": "Python: Current File",
            "type": "python",
            "request": "launch",
            "program": "run_localGPT.py",
            "args": ["--device_type", "mps",
                    ],
            "console": "integratedTerminal",
            "justMyCode": true
        }
    ]
}
```
Added the `LlamaCpp(**kwargs)` conversion exception message. Should we remove the `return None` part as well?