### PR TITLE
Fail hard if model can't be loaded.

### DIFF
--- a/load_models.py
+++ b/load_models.py
@@ -55,9 +55,10 @@ def load_quantized_model_gguf_ggml(model_id, model_basename, device_type, loggin
 
         return LlamaCpp(**kwargs)
     except:
+        logging.info("Failed to load model.")
         if "ggml" in model_basename:
             logging.INFO("If you were using GGML model, LLAMA-CPP Dropped Support, Use GGUF Instead")
-        return None
+        raise
 
 
 def load_quantized_model_qptq(model_id, model_basename, device_type, logging):


### PR DESCRIPTION
when model fail to load, it returns None, which later results into

```
pydantic.error_wrappers.ValidationError: 1 validation error for LLMChain
```

I had hard time to find out what's the problem (in my case it was missing AVX2 CPU support). Revealing the original load error message would be much easier to follow and debug.