### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ sentence-transformers
 faiss-cpu
 huggingface_hub
 transformers
-protobuf==3.20.0; sys_platform != 'darwin'
-protobuf==3.20.0; sys_platform == 'darwin' and platform_machine != 'arm64'
+protobuf==3.20.2; sys_platform != 'darwin'
+protobuf==3.20.2; sys_platform == 'darwin' and platform_machine != 'arm64'
 protobuf==3.20.3; sys_platform == 'darwin' and platform_machine == 'arm64'
 auto-gptq==0.2.2
 docx2txt


### PR DESCRIPTION
INFO: pip is looking at multiple versions of onnx to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install protobuf==3.20.0 and unstructured-inference because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested protobuf==3.20.0
    onnx 1.14.1 depends on protobuf>=3.20.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict