### PR TITLE
Change markdown files to use the UnstructuredMarkdownLoader

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -5,7 +5,7 @@ from chromadb.config import Settings
 
 # https://python.langchain.com/en/latest/modules/indexes/document_loaders/examples/excel.html?highlight=xlsx#microsoft-excel
 from langchain.document_loaders import CSVLoader, PDFMinerLoader, TextLoader, UnstructuredExcelLoader, Docx2txtLoader
-from langchain.document_loaders import UnstructuredFileLoader
+from langchain.document_loaders import UnstructuredFileLoader, UnstructuredMarkdownLoader
 
 
 # load_dotenv()
@@ -44,7 +44,7 @@ N_BATCH = 512
 # https://python.langchain.com/en/latest/_modules/langchain/document_loaders/excel.html#UnstructuredExcelLoader
 DOCUMENT_MAP = {
     ".txt": TextLoader,
-    ".md": TextLoader,
+    ".md": UnstructuredMarkdownLoader,
     ".py": TextLoader,
     # ".pdf": PDFMinerLoader,
     ".pdf": UnstructuredFileLoader,


### PR DESCRIPTION
I found that the prompt questions on my markdown files had better answers when using the UnstructuredMarkdownLoader to ingest the documents.