### PR TITLE
Update run_localGPT.py to be able to run without an internet connection

### DIFF
--- a/run_localGPT.py
+++ b/run_localGPT.py
@@ -32,6 +32,7 @@ from constants import (
     MODEL_BASENAME,
     MAX_NEW_TOKENS,
     MODELS_PATH,
+    CHROMA_SETTINGS
 )
 
 
@@ -122,6 +123,7 @@ def retrieval_qa_pipline(device_type, use_history, promptTemplate_type="llama"):
     db = Chroma(
         persist_directory=PERSIST_DIRECTORY,
         embedding_function=embeddings,
+        client_settings=CHROMA_SETTINGS
     )
     retriever = db.as_retriever()
 


### PR DESCRIPTION
When running run_localGPT.py without an internet connection, it crashes because Chroma tries to connect to the internet to send telemetry information for Posthog. This fix makes the Chroma instance respect the telemetry settings defined in constants.py