### PR TITLE
Specify v2.2.2 for sentence transformers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ langchain==0.0.267
 chromadb==0.4.6
 pdfminer.six==20221105
 InstructorEmbedding
-sentence-transformers
+sentence-transformers==2.2.2
 faiss-cpu
 huggingface_hub
 transformers


### PR DESCRIPTION
As discussed in issue #722, the new version 2.3.0 of the Python package sentence-transformers brings a breaking change that causes the following error:

`TypeError: INSTRUCTOR._load_sbert_model() got an unexpected keyword argument 'token'`

This PR mentions v2.2.2 for sentence-transformers in the requirements.txt file.


