### PR TITLE
Add ingest folders with symlink

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -62,7 +62,7 @@ def load_document_batch(filepaths):
 def load_documents(source_dir: str) -> list[Document]:
     # Loads all documents from the source documents directory, including nested folders
     paths = []
-    for root, _, files in os.walk(source_dir):
+    for root, _, files in os.walk(source_dir, followlinks=True):
         for file_name in files:
             print("Importing: " + file_name)
             file_extension = os.path.splitext(file_name)[1]


### PR DESCRIPTION
Hi, I wanted to propose a simple change in `ingest` script.

Reason behind it: I store my documents in a separate storage and instead of copying files I symlink them to `SOURCE_DOCUMENTS` folder. It works when I link documents one by one (i.e. giving full path for each file). But I have documents in nested folders and linking directories not work due to `followlinks` flag defaults to `False`. [Documentation](https://docs.python.org/3/library/os.html#os.walk)

The PR solves this problem.