### PR TITLE
Update README.md to add common error for python and cuda versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,3 +326,10 @@ This is a test project to validate the feasibility of a fully local solution for
        conda uninstall tokenizers, transformers
        pip install transformers
     ```
+- Pip Fails to install requirements due to no matching distributions of packages such as autoawq
+  - Check CUDA Version <= 11.8
+  - Check python version <=3.11
+    ```shell
+       conda list -n localgpt
+       conda install python=3.11
+    ```


### PR DESCRIPTION
Following the install instructions leads to errors on windows systems with python 3.12 and cuda=12 due to missing .whl
Rolling these back worked for me.