### PR TITLE
Fix wrong `--qa_save` reference in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ python run_localGPT.py --use_history
 You can store user questions and model responses with flag `--save_qa` into a csv file `/local_chat_history/qa_log.csv`. Every interaction will be stored. 
 
 ```shell
-python run_localGPT.py --qa_save
+python run_localGPT.py --save_qa
 ```
 
 # Run the Graphical User Interface


### PR DESCRIPTION
Update wrong `--qa_save` reference, as per `localGPT` help:

```
❯ python run_localGPT.py --help
Usage: run_localGPT.py [OPTIONS]

  Implements the main information retrieval task for a localGPT.

  This function sets up the QA system by loading the necessary embeddings,
  vectorstore, and LLM model. It then enters an interactive loop where the
  user can input queries and receive answers. Optionally, the source documents
  used to derive the answers can also be displayed.

  Parameters: - device_type (str): Specifies the type of device where the
  model will run, e.g., 'cpu', 'mps', 'cuda', etc. - show_sources (bool): Flag
  to determine whether to display the source documents used for answering. -
  use_history (bool): Flag to determine whether to use chat history or not.

  Notes: - Logging information includes the device type, whether source
  documents are displayed, and the use of history. - If the models directory
  does not exist, it creates a new one to store models. - The user can exit
  the interactive loop by entering "exit". - The source documents are
  displayed if the show_sources flag is set to True.

Options:
  --device_type [cpu|cuda|ipu|xpu|mkldnn|opengl|opencl|ideep|hip|ve|fpga|ort|xla|lazy|vulkan|mps|meta|hpu|mtia]
                                  Device to run on. (Default is cuda)
  -s, --show_sources              Show sources along with answers (Default is
                                  False)
  -h, --use_history               Use history (Default is False)
  --model_type [llama|mistral|non_llama]
                                  model type, llama, mistral or non_llama
  --save_qa                       whether to save Q&A pairs to a CSV file
                                  (Default is False)
  --help                          Show this message and exit.
```