### PR TITLE
Restore context windows size to 8096 tokens in contants config

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -29,7 +29,7 @@ CHROMA_SETTINGS = Settings(
 )
 
 # Context Window and Max New Tokens
-CONTEXT_WINDOW_SIZE = 2048
+CONTEXT_WINDOW_SIZE = 8096
 MAX_NEW_TOKENS = CONTEXT_WINDOW_SIZE  # int(CONTEXT_WINDOW_SIZE/4)
 
 #### If you get a "not enough space in the buffer" error, you should reduce the values below, start with half of the original values and keep halving the value until the error stops appearing


### PR DESCRIPTION
This pull request restores the context window size to 8096 tokens. A recent adjustment (https://github.com/PromtEngineer/localGPT/pull/828) had inadvertently reduced the context size, potentially impacting the user's application's performance and ability to process larger inputs effectively.

@PromtEngineer , @siddhivelankar23 
Please checkout the comment and see if that makes sense: https://github.com/PromtEngineer/localGPT/pull/828#pullrequestreview-2400307411