### PR TITLE
Fix: Ensure database directory exists to avoid sqlite3.OperationalError

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -3,6 +3,7 @@ import uuid
 import json
 from datetime import datetime
 from typing import List, Dict, Optional, Tuple
+from pathlib import Path
 
 class ChatDatabase:
     def __init__(self, db_path: str = None):
@@ -15,6 +16,10 @@ class ChatDatabase:
                 self.db_path = "backend/chat_data.db"
         else:
             self.db_path = db_path
+
+        # Ensure DB directory exists to avoid OperationalError on fresh systems
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+
         self.init_database()
     
     def init_database(self):


### PR DESCRIPTION
This PR fixes a startup crash when the `backend/chat_data.db` path does not exist during first-time setup.

Fix:
- Adds `Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)` in `ChatDatabase.__init__()` to ensure the DB directory exists before trying to connect via SQLite.

Related error:
This resolves a common issue when running the app locally without a pre-created `backend/` directory.
Tested locally on Windows and Linux. Compatible with Docker setup as well.
